### PR TITLE
Hybrid resolver using both in-memory cache and eBPF map

### DIFF
--- a/cmd/fsprobe/cmd/cmd.go
+++ b/cmd/fsprobe/cmd/cmd.go
@@ -133,6 +133,12 @@ stdout`)
 		"",
 		false,
 		`Output version information and exit`)
+	FSProbeCmd.Flags().BoolVarP(
+		&options.Systemd,
+		"systemd",
+		"",
+		false,
+		`Set up logging from a systemd unit`)
 }
 
 func printVersion() error {

--- a/cmd/fsprobe/cmd/fsprobe.go
+++ b/cmd/fsprobe/cmd/fsprobe.go
@@ -80,7 +80,7 @@ func initLogging() {
 		DisableTimestamp: options.Systemd,
 	})
 	logrus.SetOutput(os.Stdout)
-	logrus.SetLevel(logrus.InfoLevel)
+	logrus.SetLevel(logrus.WarnLevel)
 	if options.Verbose {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/cmd/fsprobe/cmd/fsprobe.go
+++ b/cmd/fsprobe/cmd/fsprobe.go
@@ -76,10 +76,8 @@ func runFSProbeCmd(cmd *cobra.Command, args []string) error {
 }
 
 func initLogging() {
-	logrus.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:          true,
-		TimestampFormat:        "2006-01-02T15:04:05Z",
-		DisableLevelTruncation: true,
+	logrus.SetFormatter(&utils.TextFormatter{
+		DisableTimestamp: options.Systemd,
 	})
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.InfoLevel)

--- a/cmd/fsprobe/cmd/model.go
+++ b/cmd/fsprobe/cmd/model.go
@@ -22,6 +22,7 @@ type CLIOptions struct {
 	Format         string
 	Verbose        bool
 	Version        bool
+	Systemd        bool
 	OutputFilePath string
 	FSOptions      model.FSProbeOptions
 }

--- a/ebpf/defs.h
+++ b/ebpf/defs.h
@@ -601,4 +601,18 @@ struct bpf_map_def SEC("maps/enabled_events") enabled_events = {
 
 #define EXT4_SUPER_MAGIC    0xef53
 
+#ifndef CORE
+#define READ_KERN(ptr) ({ typeof(ptr) _val;                             \
+                          __builtin_memset(&_val, 0, sizeof(_val));     \
+                          bpf_probe_read(&_val, sizeof(_val), &ptr);    \
+                          _val;                                         \
+                        })
+#else
+#define READ_KERN(ptr) ({ typeof(ptr) _val;                             \
+                          __builtin_memset(&_val, 0, sizeof(_val));     \
+                          bpf_core_read(&_val, sizeof(_val), &ptr);    \
+                          _val;                                         \
+                        })
+#endif
+
 #endif

--- a/ebpf/dentry.h
+++ b/ebpf/dentry.h
@@ -348,8 +348,8 @@ __attribute__((always_inline)) static int resolve_paths(void *ctx, struct dentry
         if (cache->fs_event.event == EVENT_RENAME || cache->fs_event.event == EVENT_LINK) {
             // Make sure to resolve the new inode regardless of the cache
             bpf_map_delete_elem(&path_fragments, &key);
-            bpf_printk("resolve_paths: remove entry for ino=%ld/mnt_id=%d",
-                       key.ino, key.mount_id);
+            //bpf_printk("resolve_paths: remove entry for ino=%ld/mnt_id=%d",
+            //           key.ino, key.mount_id);
         }
         if (cache->target_pathname) {
             embed_pathname(&key, cache, flag&RESOLVE_TARGET);

--- a/ebpf/dentry.h
+++ b/ebpf/dentry.h
@@ -305,6 +305,8 @@ __attribute__((always_inline)) static void embed_pathname(struct path_key_t *bas
         bpf_probe_read_str(&value->name, sizeof(value->name), (void *)cache->target_pathname);
     }
 #ifdef DEBUG
+    bpf_printk("embed_path: name=%s, ino=%ld/mnt_id=%d.",
+               value->name, key.ino, key.mount_id);
     bpf_printk("embed_path: parent=ino:%ld/mnt_id=%d (%ld/%d).",
                value->parent.ino, value->parent.mount_id,
                key.ino, key.mount_id);

--- a/ebpf/dentry.h
+++ b/ebpf/dentry.h
@@ -346,6 +346,8 @@ __attribute__((always_inline)) static int resolve_paths(void *ctx, struct dentry
         if (cache->fs_event.event == EVENT_RENAME || cache->fs_event.event == EVENT_LINK) {
             // Make sure to resolve the new inode regardless of the cache
             bpf_map_delete_elem(&path_fragments, &key);
+            bpf_printk("resolve_paths: remove entry for ino=%ld/mnt_id=%d",
+                       key.ino, key.mount_id);
         }
         if (cache->target_pathname) {
             embed_pathname(&key, cache, flag&RESOLVE_TARGET);
@@ -363,7 +365,17 @@ __attribute__((always_inline)) static int resolve_paths(void *ctx, struct dentry
 __attribute__((always_inline)) static void reset_cache_entry(struct dentry_cache_t *data_cache) {
     data_cache->fs_event.src_path_key = 0;
     data_cache->fs_event.target_path_key = 0;
+    data_cache->fs_event.mode = 0;
+    data_cache->fs_event.flags = 0;
     data_cache->cursor = 0;
+    data_cache->pathname = 0;
+    data_cache->target_pathname = 0;
 }
+
+//__attribute__((always_inline)) static int is_null_path_key(struct path_key_t *key) {
+//    if (key->inode == 0 && key->mount_id == 0)
+//        return 1;
+//    return 0;
+//}
 
 #endif

--- a/ebpf/filename.h
+++ b/ebpf/filename.h
@@ -95,11 +95,9 @@ int kprobe_link_path_walk(struct pt_regs *ctx) {
                 syscall->open.file.path_key.mount_id = get_path_mount_id(base_path);
                 syscall->open.file.path_key.ino = get_path_dentry_ino(base_path);
 #ifdef DEBUG
-                if (syscall->open.file.path_key.mount_id == 253) {
-                    bpf_printk("link_path_walk_e: open, base dir mnt_id=%ld/ino=%ld.",
-                               syscall->open.file.path_key.mount_id,
-                               syscall->open.file.path_key.ino);
-                    }
+                bpf_printk("link_path_walk_e: open, base dir mnt_id=%ld/ino=%ld.",
+                           syscall->open.file.path_key.mount_id,
+                           syscall->open.file.path_key.ino);
 #endif
             }
             break;

--- a/ebpf/filter.h
+++ b/ebpf/filter.h
@@ -25,11 +25,17 @@ __attribute__((always_inline)) static int match_src(struct dentry_cache_t *data_
 {
     // Look for the inode in the cached_inodes map
     if (bpf_map_lookup_elem(&inodes_filter, &data_cache->fs_event.src_inode) == NULL) {
+        //if (data_cache->fs_event.src_mount_id == 253) {
+        //    bpf_printk("filter(src): unmatched on ino=%ld, trying parent.", data_cache->fs_event.src_inode);
+        //}
         // Look for the parent inode
         struct dentry *d_parent;
         bpf_probe_read(&d_parent, sizeof(d_parent), &data_cache->src_dentry->d_parent);
         u32 ino = get_dentry_ino(d_parent);
         if (bpf_map_lookup_elem(&inodes_filter, &ino) == NULL) {
+            //if (data_cache->fs_event.src_mount_id == 253) {
+            //    bpf_printk("filter(src): unmatched on par.ino=%ld.", ino);
+            //}
             return 0;
         }
     }

--- a/ebpf/mnt.h
+++ b/ebpf/mnt.h
@@ -16,22 +16,20 @@ int kprobe_mnt_want_write(struct pt_regs *ctx) {
     struct vfsmount *mnt = (struct vfsmount *)PT_REGS_PARM1(ctx);
 
     switch (syscall->type) {
-    case EVENT_MKDIR:
-        break;
     case EVENT_RENAME:
-        if (syscall->rename.src_file.path_key.mount_id > 0)
-            return 0;
+        //if (syscall->rename.src_file.path_key.mount_id > 0)
+        //    return 0;
         syscall->rename.src_file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         syscall->rename.target_file.path_key.mount_id = syscall->rename.src_file.path_key.mount_id;
         break;
     case EVENT_RMDIR:
-        if (syscall->rmdir.file.path_key.mount_id > 0)
-            return 0;
+        //if (syscall->rmdir.file.path_key.mount_id > 0)
+        //    return 0;
         syscall->rmdir.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_UNLINK:
-        if (syscall->unlink.file.path_key.mount_id > 0)
-            return 0;
+        //if (syscall->unlink.file.path_key.mount_id > 0)
+        //    return 0;
         syscall->unlink.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     }

--- a/ebpf/open.h
+++ b/ebpf/open.h
@@ -37,6 +37,10 @@ void get_dentry_name(struct dentry *dentry, void *buffer, size_t n);
 // uninitialized upon entry and can only be access in the return probe
 __attribute__((always_inline)) static int trace_path_openat(struct pt_regs *ctx, struct path *path)
 {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
+    if (!syscall)
+        return 0;
+
     u32 cpu = bpf_get_smp_processor_id();
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_open_cache_builder, &cpu);
     if (!data_cache)
@@ -65,6 +69,7 @@ __attribute__((always_inline)) static int trace_path_openat_ret(struct pt_regs *
         return 0;
 
     struct file *file = (struct file *)PT_REGS_RC(ctx);
+
     if (!IS_ERR(file))
     {
         // Do not trace success since it will be available
@@ -79,8 +84,11 @@ __attribute__((always_inline)) static int trace_path_openat_ret(struct pt_regs *
 
     data_cache->fs_event.flags = syscall->open.flags;
     data_cache->fs_event.retval = PTR_ERR(file);
-    data_cache->fs_event.src_inode = syscall->open.file.path_key.ino;
-    data_cache->fs_event.src_mount_id = syscall->open.file.path_key.mount_id;
+    //data_cache->fs_event.src_inode = syscall->open.file.path_key.ino;
+    //data_cache->fs_event.src_mount_id = syscall->open.file.path_key.mount_id;
+    data_cache->fs_event.src_inode = get_path_dentry_ino(data_cache->path);
+    data_cache->fs_event.src_mount_id = get_path_mount_id(data_cache->path);
+
     // It seems that at least with EACCES, the path cached
     // upon entry into path_openat is not initialized enough
     // to read anything beyond inode (e.g. no dentry name and
@@ -92,8 +100,10 @@ __attribute__((always_inline)) static int trace_path_openat_ret(struct pt_regs *
     bpf_probe_read(&dentry, sizeof(struct dentry *), &data_cache->path->dentry);
     data_cache->src_dentry = dentry;
 
-    if (!match(data_cache, FILTER_SRC))
+    if (!match(data_cache, FILTER_SRC)) {
+        bpf_map_delete_elem(&dentry_open_cache, &key);
         return 0;
+    }
 
 #ifdef DEBUG
     bpf_printk("path_openat_x: match, resolve paths, ino=%ld, mnt_id=%d, ret=%d.",
@@ -159,15 +169,19 @@ __attribute__((always_inline)) static int trace_open_ret(struct pt_regs *ctx)
     data_cache->fs_event.src_inode = get_dentry_ino(dentry);
     data_cache->fs_event.src_mount_id = get_path_mount_id(data_cache->path);
 
+    if (!match(data_cache, FILTER_SRC)) {
+        // Clean up the dentry cache since the matching is in
+        // the exit probe
+        bpf_map_delete_elem(&dentry_cache, &key);
+        return 0;
+    }
+
 #ifdef DEBUG
     bpf_printk("vfs_open_x: resolve paths, ino=%ld, mnt_id=%d, ret=%d.",
                data_cache->fs_event.src_inode,
                data_cache->fs_event.src_mount_id,
                data_cache->fs_event.retval);
 #endif
-
-    if (!match(data_cache, FILTER_SRC))
-        return 0;
 
     resolve_paths(ctx, data_cache, RESOLVE_SRC | EMIT_EVENT);
     bpf_map_delete_elem(&dentry_cache, &key);

--- a/ebpf/open.h
+++ b/ebpf/open.h
@@ -41,6 +41,7 @@ __attribute__((always_inline)) static int trace_path_openat(struct pt_regs *ctx,
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_open_cache_builder, &cpu);
     if (!data_cache)
         return 0;
+    reset_cache_entry(data_cache);
 
     u64 key = fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.event = EVENT_OPEN;
@@ -115,18 +116,11 @@ __attribute__((always_inline)) static int trace_open(struct pt_regs *ctx, struct
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_cache_builder, &cpu);
     if (!data_cache)
         return 0;
-
     reset_cache_entry(data_cache);
+
     u64 key = fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.event = EVENT_OPEN;
-    struct dentry *dentry;
-    bpf_probe_read(&dentry, sizeof(struct dentry *), &path->dentry);
-    data_cache->fs_event.src_inode = get_dentry_ino(dentry);
-    data_cache->fs_event.src_mount_id = get_path_mount_id(path);
-    data_cache->src_dentry = dentry;
-
-    if (!match(data_cache, FILTER_SRC))
-        return 0;
+    data_cache->path = path;
 
 #ifdef DEBUG
     struct nameidata *nd = (struct nameidata *)path;
@@ -151,21 +145,29 @@ __attribute__((always_inline)) static int trace_open_ret(struct pt_regs *ctx)
     struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
-    //bpf_printk("open_x: remove syscall from stack.");
 
     u64 key = bpf_get_current_pid_tgid();
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_cache, &key);
     if (!data_cache)
         return 0;
 
-    data_cache->fs_event.flags = syscall->open.flags;
     data_cache->fs_event.retval = PT_REGS_RC(ctx);
+    data_cache->fs_event.flags = syscall->open.flags;
+    struct dentry *dentry;
+    bpf_probe_read(&dentry, sizeof(struct dentry *), &data_cache->path->dentry);
+    data_cache->src_dentry = dentry;
+    data_cache->fs_event.src_inode = get_dentry_ino(dentry);
+    data_cache->fs_event.src_mount_id = get_path_mount_id(data_cache->path);
+
 #ifdef DEBUG
     bpf_printk("vfs_open_x: resolve paths, ino=%ld, mnt_id=%d, ret=%d.",
                data_cache->fs_event.src_inode,
                data_cache->fs_event.src_mount_id,
                data_cache->fs_event.retval);
 #endif
+
+    if (!match(data_cache, FILTER_SRC))
+        return 0;
 
     resolve_paths(ctx, data_cache, RESOLVE_SRC | EMIT_EVENT);
     bpf_map_delete_elem(&dentry_cache, &key);

--- a/ebpf/rename.h
+++ b/ebpf/rename.h
@@ -146,7 +146,8 @@ __attribute__((always_inline)) static int trace_rename_ret(struct pt_regs *ctx)
 
 #ifdef DEBUG
     bpf_printk("vfs_rename_x: ret=%d", data_cache->fs_event.retval);
-    bpf_printk("vfs_rename_x: src(ino=%ld/mnt_id=%d)",
+    bpf_printk("vfs_rename_x: src(key=%ld/ino=%ld/mnt_id=%d)",
+               data_cache->fs_event.src_path_key,
                data_cache->fs_event.src_inode,
                data_cache->fs_event.src_mount_id);
     bpf_printk("vfs_rename_x: tgt(ino=%ld/mnt_id=%d)",

--- a/ebpf/rename.h
+++ b/ebpf/rename.h
@@ -48,6 +48,7 @@ int __attribute__((always_inline)) trace__sys_rename_ret(struct pt_regs *ctx) {
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_cache_builder, &cpu);
     if (!data_cache)
         return 0;
+    reset_cache_entry(data_cache);
 
     fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.retval = ret;
@@ -102,6 +103,7 @@ __attribute__((always_inline)) static int trace_rename(struct pt_regs *ctx, stru
     if (!data_cache)
         return 0;
     reset_cache_entry(data_cache);
+
     u64 key = fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.event = EVENT_RENAME;
     data_cache->fs_event.src_inode = get_dentry_ino(old_dentry);

--- a/ebpf/syscalls.h
+++ b/ebpf/syscalls.h
@@ -10,8 +10,6 @@
 struct syscall_cache_t {
     u64 type;
 
-    //struct dentry_resolver_input_t resolver;
-
     union {
         struct {
             int flags;

--- a/ebpf/unlink.h
+++ b/ebpf/unlink.h
@@ -65,6 +65,7 @@ long __attribute__((always_inline)) trace__sys_unlink_ret(struct unlinkat_ret_ar
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_cache_builder, &cpu);
     if (!data_cache)
         return 0;
+    reset_cache_entry(data_cache);
 
     fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.retval = ret;
@@ -96,8 +97,8 @@ __attribute__((always_inline)) static int trace_unlink(struct pt_regs *ctx, stru
     struct dentry_cache_t *data_cache = bpf_map_lookup_elem(&dentry_cache_builder, &cpu);
     if (!data_cache)
         return 0;
-
     reset_cache_entry(data_cache);
+
     u64 key = fill_process_data(&data_cache->fs_event.process_data);
     data_cache->fs_event.event = EVENT_UNLINK;
     data_cache->fs_event.src_inode = get_dentry_ino(dentry);
@@ -106,6 +107,12 @@ __attribute__((always_inline)) static int trace_unlink(struct pt_regs *ctx, stru
 
     if (!match(data_cache, FILTER_SRC))
         return 0;
+
+#ifdef DEBUG
+    bpf_printk("unlink_e: ino=%ld/mnt_id=%d",
+               data_cache->fs_event.src_inode,
+               data_cache->fs_event.src_mount_id);
+#endif
 
     bpf_map_update_elem(&dentry_cache, &key, data_cache, BPF_ANY);
     return 0;

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/Gui774ume/ebpf v0.0.0-20200411100314-4233cdb60f05
-	github.com/google/go-cmp v0.2.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/pkg/errors v0.9.1
 	github.com/shuLhan/go-bindata v4.0.0+incompatible
 	github.com/sirupsen/logrus v1.6.0
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
-replace github.com/Gui774ume/ebpf => github.com/a-palchikov/ebpf v0.0.0-20211227225143-47ddcbc19f82
+replace github.com/Gui774ume/ebpf => github.com/a-palchikov/ebpf v0.0.0-20220111164015-d05e28019a42

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 h1:UUppSQnhf4Yc6xGxSkoQpPhb7RVzuv5Nb1mwJ5VId9s=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/a-palchikov/ebpf v0.0.0-20211227225143-47ddcbc19f82 h1:k17XOG2dlLL6u1M+b4jGYe8rgA6PuFNng9HmUfbQsu0=
-github.com/a-palchikov/ebpf v0.0.0-20211227225143-47ddcbc19f82/go.mod h1:LKA4oWjvzH4g598cq+NU3zBxkVA1lEf9bADxBxBlw9c=
+github.com/a-palchikov/ebpf v0.0.0-20220111164015-d05e28019a42 h1:JbWS5tS2vWXnlhSb+ZYDfOA8z8AmYjkH129DDw/6UDY=
+github.com/a-palchikov/ebpf v0.0.0-20220111164015-d05e28019a42/go.mod h1:LKA4oWjvzH4g598cq+NU3zBxkVA1lEf9bADxBxBlw9c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -43,12 +43,13 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/fsprobe/fsprobe.go
+++ b/pkg/fsprobe/fsprobe.go
@@ -272,19 +272,21 @@ func (fsp *FSProbe) addTopLevelWatch(paths ...string) error {
 				if !ok {
 					continue
 				}
-				logrus.WithField("path", fullPath).WithField("ino", uint32(stat.Ino)).Debug("Set up watch.")
-				// Add inode in cache
-				fsp.watchInode(uint32(stat.Ino), fullPath)
+				if f.IsDir() {
+					// Add inode in cache
+					fsp.watchInode(uint32(stat.Ino), fullPath)
+					logrus.WithField("path", fullPath).WithField("ino", uint32(stat.Ino)).Debug("Set up watch.")
+				}
 			}
+			// Add the directory itself to the list of watched files
+			stat, ok := fi.Sys().(*syscall.Stat_t)
+			if !ok {
+				continue
+			}
+			logrus.WithField("path", path).WithField("ino", uint32(stat.Ino)).Debug("Set up watch.")
+			fsp.watchInode(uint32(stat.Ino), path)
+
 		}
-		// Add the file (or directory itself) to the list of watched files
-		stat, ok := fi.Sys().(*syscall.Stat_t)
-		if !ok {
-			continue
-		}
-		logrus.WithField("path", path).WithField("ino", uint32(stat.Ino)).Debug("Set up watch.")
-		// Add file in cache
-		fsp.watchInode(uint32(stat.Ino), path)
 	}
 	return nil
 }

--- a/pkg/fsprobe/monitor/fs/fs.go
+++ b/pkg/fsprobe/monitor/fs/fs.go
@@ -287,23 +287,23 @@ var (
 					},
 				},
 			},
-			model.SetAttr: {
-				{
-					Name:        "setattr",
-					SectionName: "kprobe/security_inode_setattr",
-					Enabled:     false,
-					Type:        ebpf.Kprobe,
-					Constants: []string{
-						model.InodeFilteringModeConst,
-					},
-				},
-				{
-					Name:        "setattr_ret",
-					SectionName: "kretprobe/security_inode_setattr",
-					Enabled:     false,
-					Type:        ebpf.Kprobe,
-				},
-			},
+			//model.SetAttr: {
+			//	{
+			//		Name:        "setattr",
+			//		SectionName: "kprobe/security_inode_setattr",
+			//		Enabled:     false,
+			//		Type:        ebpf.Kprobe,
+			//		Constants: []string{
+			//			model.InodeFilteringModeConst,
+			//		},
+			//	},
+			//	{
+			//		Name:        "setattr_ret",
+			//		SectionName: "kretprobe/security_inode_setattr",
+			//		Enabled:     false,
+			//		Type:        ebpf.Kprobe,
+			//	},
+			//},
 		},
 		PerfMaps: []*model.PerfMap{
 			{
@@ -353,19 +353,7 @@ func (r *FSEventHandler) Handle(monitor *model.Monitor, event *model.FSEvent) {
 		log.SetOutput(os.Stdout)
 		log.SetLevel(logrus.DebugLevel)
 	}
-	logger := log.WithFields(logrus.Fields{
-		"path":       event.SrcFilename,
-		"type":       event.EventType,
-		"mnt_id":     event.SrcMountID,
-		"key":        event.SrcPathnameKey,
-		"tgt_mnt_id": event.TargetMountID,
-		"ino":        event.PrintInode(),
-		"tgt_ino":    event.TargetInode,
-		"tgt_key":    event.TargetPathnameKey,
-		"comm":       event.Comm,
-		"ret":        event.Retval,
-		"flags":      event.PrintFlags(),
-	})
+	logger := log.WithFields(model.FieldsForEvent(event))
 	logger.Info("New event.")
 	var matched bool
 	switch event.EventType {
@@ -428,11 +416,7 @@ func (r *FSEventHandler) Handle(monitor *model.Monitor, event *model.FSEvent) {
 	}
 
 	// Dispatch event
-	select {
-	case monitor.Options.EventChan <- event:
-	default:
-		logger.Debug("Dropped event.")
-	}
+	monitor.Options.EventChan <- event
 }
 
 // maybeAddInodeFilter adds a new inode filter at the specified path

--- a/pkg/model/events.go
+++ b/pkg/model/events.go
@@ -137,20 +137,20 @@ func resolvePaths(data []byte, evt *FSEvent, monitor *Monitor, read int) (err er
 		logger.Debug("Invalid mountID/inode tuple.")
 		return nil
 	}
-	evt.SrcFilename, err = monitor.DentryResolver.ResolveInode(key)
+	evt.SrcFilename, err = monitor.DentryResolver.Resolve(key)
 	if err != nil {
 		return errors.Wrap(err, "failed to resolve src dentry path")
 	}
 	switch evt.EventType {
 	case Link, Rename:
 		targetKey := evt.TargetPathKey()
-		evt.TargetFilename, err = monitor.DentryResolver.ResolveInode(targetKey)
+		evt.TargetFilename, err = monitor.DentryResolver.Resolve(targetKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to resolve target dentry path")
 		}
 		if evt.EventType == Link {
 			// Remove cache entry for link events
-			_ = monitor.DentryResolver.RemoveInode(targetKey)
+			_ = monitor.DentryResolver.Remove(targetKey)
 			// TODO(dima): why double delete?
 			//_ = monitor.DentryResolver.RemoveInode(evt.TargetMountID, evt.TargetInode)
 		}
@@ -299,7 +299,7 @@ func (fs FSEvent) PrintInode() string {
 	return strconv.FormatUint(inode, 10)
 }
 
-func (fs FSEvent) SrcPathKey() PathFragmentsKey {
+func (fs FSEvent) SrcPathKey() PathKey {
 	inode := fs.SrcInode
 	if fs.SrcPathnameKey != 0 {
 		inode = uint64(fs.SrcPathnameKey)
@@ -307,7 +307,7 @@ func (fs FSEvent) SrcPathKey() PathFragmentsKey {
 	return NewPathKey(inode, fs.SrcMountID)
 }
 
-func (fs FSEvent) TargetPathKey() PathFragmentsKey {
+func (fs FSEvent) TargetPathKey() PathKey {
 	inode := fs.TargetInode
 	if fs.TargetPathnameKey != 0 {
 		inode = uint64(fs.TargetPathnameKey)

--- a/pkg/model/monitor.go
+++ b/pkg/model/monitor.go
@@ -26,7 +26,7 @@ import (
 // Monitor - Base monitor
 type Monitor struct {
 	ResolutionModeMaps []string
-	DentryResolver     *PathFragmentsResolver
+	DentryResolver     *PathResolver
 	FSProbe            FSProbe
 	InodeFilterSection string
 	Name               string
@@ -71,7 +71,7 @@ func (m *Monitor) Configure() {
 		}
 	}
 	// Setup dentry resolver
-	m.DentryResolver, _ = NewPathFragmentsResolver(m)
+	m.DentryResolver, _ = NewPathResolver(m)
 }
 
 // GetName - Returns the name of the monitor

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,0 +1,183 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// FileField is a field with code file added to structured traces
+	FileField = "file"
+	// FunctionField is a field with function name
+	FunctionField = "func"
+	// LevelField returns logging level as set by logrus
+	LevelField = "level"
+	// Component is a field that represents component - e.g. service or
+	// function
+	Component = "trace.component"
+	// ComponentFields is a fields component
+	ComponentFields = "trace.fields"
+	// DefaultComponentPadding is a default padding for component field
+	DefaultComponentPadding = 11
+	// DefaultLevelPadding is a default padding for level field
+	DefaultLevelPadding = 4
+)
+
+// TextFormatter is logrus-compatible formatter and adds
+// file and line details to every logged entry.
+type TextFormatter struct {
+	// DisableTimestamp disables timestamp output (useful when outputting to
+	// systemd logs)
+	DisableTimestamp bool
+	// ComponentPadding is a padding to pick when displaying
+	// and formatting component field, defaults to DefaultComponentPadding
+	ComponentPadding int
+	// FormatCaller is a function to return (part) of source file path for output.
+	// Defaults to filePathAndLine() if unspecified
+	FormatCaller func() (caller string)
+}
+
+// Format implements logrus.Formatter interface and adds file and line
+func (tf *TextFormatter) Format(e *logrus.Entry) (data []byte, err error) {
+	formatCaller := tf.FormatCaller
+	if formatCaller == nil {
+		formatCaller = func() string { return "" }
+	}
+
+	caller := formatCaller()
+	w := &writer{}
+
+	// time
+	if !tf.DisableTimestamp {
+		w.writeField(e.Time.Format(time.RFC3339), noColor)
+	}
+
+	color := noColor
+	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)), color)
+
+	// always output the component field if available
+	padding := DefaultComponentPadding
+	if tf.ComponentPadding != 0 {
+		padding = tf.ComponentPadding
+	}
+	if w.Len() > 0 {
+		w.WriteByte(' ')
+	}
+	value := e.Data[Component]
+	var component string
+	if reflect.ValueOf(value).IsValid() {
+		component = fmt.Sprintf("[%v]", value)
+	}
+	component = strings.ToUpper(padMax(component, padding))
+	if component[len(component)-1] != ' ' {
+		component = component[:len(component)-1] + "]"
+	}
+	w.WriteString(component)
+
+	if e.Message != "" {
+		w.writeField(e.Message, noColor)
+	}
+
+	if len(e.Data) > 0 {
+		w.writeMap(e.Data)
+	}
+
+	if caller != "" {
+		w.writeField(caller, noColor)
+	}
+
+	w.WriteByte('\n')
+	data = w.Bytes()
+	return
+}
+
+const noColor = -1
+
+type writer struct {
+	bytes.Buffer
+}
+
+func (w *writer) writeField(value interface{}, color int) {
+	if w.Len() > 0 {
+		w.WriteByte(' ')
+	}
+	w.writeValue(value, color)
+}
+
+func (w *writer) writeValue(value interface{}, color int) {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+		if needsQuoting(s) {
+			s = fmt.Sprintf("%q", v)
+		}
+	default:
+		s = fmt.Sprintf("%v", v)
+	}
+	w.WriteString(s)
+}
+
+func (w *writer) writeError(value interface{}) {
+	w.WriteString(fmt.Sprintf("[%v]", value))
+}
+
+func (w *writer) writeKeyValue(key string, value interface{}) {
+	if w.Len() > 0 {
+		w.WriteByte(' ')
+	}
+	w.WriteString(key)
+	w.WriteByte(':')
+	if key == logrus.ErrorKey {
+		w.writeError(value)
+		return
+	}
+	w.writeValue(value, noColor)
+}
+
+func (w *writer) writeMap(m map[string]interface{}) {
+	if len(m) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if key == Component {
+			continue
+		}
+		switch value := m[key].(type) {
+		case logrus.Fields:
+			w.writeMap(value)
+		default:
+			w.writeKeyValue(key, value)
+		}
+	}
+}
+
+func needsQuoting(text string) bool {
+	for _, r := range text {
+		if !strconv.IsPrint(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func padMax(in string, chars int) string {
+	switch {
+	case len(in) < chars:
+		return in + strings.Repeat(" ", chars-len(in))
+	default:
+		return in[:chars]
+	}
+}


### PR DESCRIPTION
Adds a hybrid resolver that iteratively adds entries to the in-memory LRU cache as paths are resolved.
